### PR TITLE
Add description/example of the 'even' template func

### DIFF
--- a/manual/templates.md
+++ b/manual/templates.md
@@ -177,6 +177,22 @@ Example:
 
 {% endraw %}
 
+### even
+
+Perform $in % 2 == 0. This is a convenience function that assists with table row coloring.
+
+Example:
+
+{% raw %}
+
+	{{range $index, $element := .results}}
+	<tr class="{{if even $index}}danger{{end}}">
+		...
+	</tr>
+	{{end}}
+
+{% endraw %}
+
 ## Including
 
 Go Templates allow you to compose templates by inclusion.  For example:


### PR DESCRIPTION
This is a documentation update for an additional template function referenced in this revel pull request: https://github.com/revel/revel/pull/578

Thanks
