### PR TITLE
Fixed error in 'cache.hosts' explanation

### DIFF
--- a/manual/cache.md
+++ b/manual/cache.md
@@ -49,8 +49,8 @@ Configure the cache using these keys in `app.conf`:
   used. (default false)
 * `cache.redis` - a boolean indicating whether or not redis should be
   used. (default false)
-* `cache.hosts` - a comma separated list of hosts to use as backends.  this is
-  only used when memcached is enabled.
+* `cache.hosts` - a comma separated list of hosts to use as backends.  If the used cache is Redis,
+  only the first host in this list is used.
 
 ## Example usage
 


### PR DESCRIPTION
'cache.hosts' is used not only with memcached, but also with Redis; in that case, only the first host is taken. (see cache/init.go:46)
