### PR TITLE
Update organization.md

### DIFF
--- a/manual/organization.md
+++ b/manual/organization.md
@@ -56,7 +56,7 @@ Additionally, Revel will import any packages within `app/` (or imported
 [modules](modules.html)) that contain `init()` functions on startup, to ensure
 that all of the developer's code is initialized.
 
-The `controllers/init.go` file is a conventional location to register all of the
+The `app/init.go` file is a conventional location to register all of the
 [interceptor](interceptors.html) hooks.  The order of `init()` functions is
 undefined between source files from the same package, so collecting all of the
 interceptor definitions into the same file allows the developer to specify (and


### PR DESCRIPTION
Location to register the interceptor hooks are at 'app/init.go' and not controllers/init.go.