### PR TITLE
Update to websocket example action's import path

### DIFF
--- a/manual/websockets.md
+++ b/manual/websockets.md
@@ -21,7 +21,7 @@ Add this to the [`conf/routes`](routing.html) file:
 Then write an action like this:
 
 {% highlight go %}
-import "code.google.com/p/go.net/websocket"
+import "golang.org/x/net/websocket"
 
 func (c App) Feed(user string, ws *websocket.Conn) revel.Result {
 	...


### PR DESCRIPTION
The import "code.google.com/p/go.net/websocket" does not work, as the type does not match against the package "golang.org/x/net/websocket" used in revel/invoker.go