### PR TITLE
go get -d

### DIFF
--- a/samples/index.md
+++ b/samples/index.md
@@ -8,7 +8,7 @@ Revel provides a few sample applications to demonstrate typical usage.
 These are in a separate [github.com/revel/samples](https://github.com/revel/samples/) repository.
 
 {% highlight sh %}
-go get github.com/revel/samples
+go get -d github.com/revel/samples
 revel run github.com/revel/samples/booking
 {% endhighlight  %}
 


### PR DESCRIPTION
─$ go get github.com/revel/samples
package github.com/revel/samples
	imports github.com/revel/samples
	imports github.com/revel/samples: no buildable Go source files in /Users/orange/Documents/golang/src/github.com/revel/samples

Use -d to ignore the error message