### PR TITLE
Added Boxfuse and Amazon Web Services deployment section

### DIFF
--- a/manual/deployment.md
+++ b/manual/deployment.md
@@ -100,7 +100,7 @@ Revel maintains a *Heroku Buildpack*, allowing one-command deploys.
 
 ## Boxfuse and Amazon Web Services
 
-[Boxfuse](https://boxfuse.com) comes with first-class support for Revel apps with one-command deploys to AWS
+[Boxfuse](https://boxfuse.com) comes with first-class support for Revel apps with one-command deploys to AWS.
 
 - Visit the [Get Started with Boxfuse and Revel](https://boxfuse.com/getstarted/revel) guide to be up and running on AWS in minutes
 - See the [Boxfuse Revel reference documentation](https://boxfuse.com/docs/payloads/revel) for details.

--- a/manual/deployment.md
+++ b/manual/deployment.md
@@ -98,6 +98,14 @@ Revel maintains a *Heroku Buildpack*, allowing one-command deploys.
 - See the [README](https://github.com/revel/heroku-buildpack-go-revel/blob/master/README.md) for usage instructions.
 
 
+## Boxfuse and Amazon Web Services
+
+[Boxfuse](https://boxfuse.com) comes with first-class support for Revel apps with one-command deploys to AWS
+
+- Visit the [Get Started with Boxfuse and Revel](https://boxfuse.com/getstarted/revel) guide to be up and running on AWS in minutes
+- See the [Boxfuse Revel reference documentation](https://boxfuse.com/docs/payloads/revel) for details.
+
+
 ## Cross-compilation
 
 In order to create a cross-compile environment, you need to build go from source.


### PR DESCRIPTION
Boxfuse has first-class support for Revel apps. With one command (`boxfuse run my-revel-app.tar.gz -env=prod`), Boxfuse provisions, configures and secures all necessary AWS infrastructure and rolls out the Revel app with zero-downtime blue/green deployments.

Port configuration is inferred directly from Revel's app.conf file and all necessary AWS resources are configured accordingly.

We believe this is by far the easiest way for Revel users to get up and running on AWS.

*Disclaimer: I am Boxfuse's founder and CEO*