### PR TITLE
Warn users about test go files

### DIFF
--- a/modules/testing.md
+++ b/modules/testing.md
@@ -17,6 +17,8 @@ Tests needs to be in the `tests/` directory:
 		public/
 		tests/    <----
 
+<div class="alert alert-danger"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> WARNING: The name of test file should avoid naming like name_test.go format which would be ignored by go build tool. Please check the <a href="http://stackoverflow.com/questions/29136488/go-no-buildable-go-source-file-in">Detail</a>.</div>
+
 A simple test file looks like the following:
 
 {% highlight go %}

--- a/modules/testing.md
+++ b/modules/testing.md
@@ -17,7 +17,7 @@ Tests needs to be in the `tests/` directory:
 		public/
 		tests/    <----
 
-<div class="alert alert-danger"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> WARNING: The name of test file should avoid naming like name_test.go format which would be ignored by go build tool. Please check the <a href="http://stackoverflow.com/questions/29136488/go-no-buildable-go-source-file-in">Detail</a>.</div>
+<div class="alert alert-danger"><span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span> WARNING: The name of test file should avoid naming like name_test.go format which would be ignored by go build tool. Please check the <a href="https://golang.org/cmd/go/#hdr-Compile_packages_and_dependencies">Detail</a>.</div>
 
 A simple test file looks like the following:
 


### PR DESCRIPTION
Add warning to notice people not name test file like _test.go format. This format is go test file, would be ignored by go build tool.
In revel we need to compile the test file to run testing. So avoid this format.