### PR TITLE
use of 'gem' naming in configuration is deprecated. use 'plugins'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ lsi: false
 highlighter: rouge
 markdown: kramdown
 jekyll-redirect-from: true
-gems:
+plugins:
   - jekyll-redirect-from
   - octopress-escape-code
 whitelist:


### PR DESCRIPTION
Renamed 'gem' to 'plugins' for _config.yml

re the console: 
`Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.`