### PR TITLE
resp.Out.Write work only once

### DIFF
--- a/manual/results.md
+++ b/manual/results.md
@@ -200,7 +200,7 @@ type MyHtml string
 
 func (r MyHtml) Apply(req *revel.Request, resp *revel.Response) {
 	resp.WriteHeader(http.StatusOK, "text/html")
-	resp.Out.Write([]byte(r))
+	resp.GetWriter().Write([]byte(r))
 }
 ```
 


### PR DESCRIPTION
Hi,

resp.Out.Write worked only once, after I had an nil error, I looked at the revel source code and saw the use of 
resp.GetWriter().Write([]byte(r))
and when I have replaced the previous line it works on every reload.

Whaly