### PR TITLE
Add missing gem dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This [jekyll](http://jekyllrb.com/) powered site is located at [revel.github.io]
 To compile and view the site locally:
 
 ```
-$ gem install jekyll kramdown
+$ gem install jekyll kramdown jekyll-redirect-from octopress-escape-code
 $ git clone git@github.com:revel/revel.github.io.git
 $ cd revel.github.io
 $ jekyll serve


### PR DESCRIPTION
I wanted to start working on some documentation changes and faced the following error.
```
$ jekyll serve
Configuration file: /Users/rik/src/github.com/revel/revel.github.io/_config.yml
  Dependency Error: Yikes! It looks like you don't have jekyll-redirect-from or one of its dependencies installed. In order to use Jekyll as currently configured, you'll need to install this gem. The full error message from Ruby is: 'cannot load such file -- jekyll-redirect-from' If you run into trouble, you can find helpful resources at https://jekyllrb.com/help/!
jekyll 3.7.2 | Error:  jekyll-redirect-from
```

We should add this and the other dependency found in _config.yml to the readme. :-)

Greetings,

Rik