### PR TITLE
Update server-engine-fasthttp to clarify the module addition

### DIFF
--- a/modules/server-engine-fasthttp.md
+++ b/modules/server-engine-fasthttp.md
@@ -5,13 +5,17 @@ github:
   labels:
     - topic-server-engine
 ---
-This module is the for [FastHTTP](https://github.com/valyala/fasthttp) server engine.
-It does not support WebSockets.
+This module wraps the [FastHTTP](https://github.com/valyala/fasthttp) server engine.
+Please note that it does not support WebSockets.
 
-###App.conf
+### Setup
+
+Set the following keys in your application’s app.conf:
 - **server.engine** You must set this to `fasthttp` in order to use this server engine
+- **module.fasthttp** You must set this to `github.com/revel/modules/server-engine/fasthttp` to register the fasthttp server engine
 
-###Other Notes
+### Other Notes
+
 All features from supported by a regular HTTP engine is supported by this server engine.
 Memory usage is decreased because this engine makes reuse of allocated structures to
 handle requests. This should also increase overall runtime performance and throughput.


### PR DESCRIPTION
The current documentation lacks information on how to enable FastHTTP for applications. Perhaps also note the user to add module.fasthttp to register the fasthttp server-engine.

also headers were not working in the rendered output.