### PR TITLE
Update database.md to link to newer GORM path

### DIFF
--- a/manual/database.md
+++ b/manual/database.md
@@ -9,7 +9,7 @@ godoc:
 ---
 
 Revel does not come *configured* with a database or ORM interface. There are modules like
-[GORM](https://github.com/revel/modules/tree/master/gorm) that can be used to provide this
+[GORM](https://github.com/revel/modules/tree/master/orm/gorm) that can be used to provide this
 functionality. But ultimately it's up to the developer what to use and how to use. 
 
 - The [booking sample application](/examples/booking.html) has an example 


### PR DESCRIPTION
Gorm was subject of a refactoring on https://github.com/revel/modules/pull/51

This PR updates references to gorm in the documentation.