### PR TITLE
Fix #203

### DIFF
--- a/tutorial/createapp.md
+++ b/tutorial/createapp.md
@@ -5,8 +5,6 @@ layout: tutorial
 
 Use the [`revel`](/manual/tool.html#mew) command line tool to create a new application in your GOPATH and run it:
 ```commandline
-
-$ export GOPATH="/home/me/gostuff"
 $ cd $GOPATH
 $ revel new -a myapp
 Revel executing: create a skeleton Revel application


### PR DESCRIPTION
The first command in this tutorial sets the GOPATH to a different value than the one given in https://revel.github.io/tutorial/gettingstarted.html#set_up_your_gopath.
This might confuse users and seems like an unnecessary duplication.
Would it make sense to remove the following line?
`$ export GOPATH="/home/me/gostuff"`